### PR TITLE
Migrate background update to use BGTaskScheduler

### DIFF
--- a/4champ.xcodeproj/project.pbxproj
+++ b/4champ.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		7397C1E729091D9D002D5CDB /* uade_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7397C1E129091BC3002D5CDB /* uade_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		739B4BF42720850200C2D69F /* RadioSessionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739B4BF32720850200C2D69F /* RadioSessionCell.swift */; };
 		73CE92E52AAF03D1000BFC1C /* PlaylistPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE92E42AAF03D1000BFC1C /* PlaylistPresenter.swift */; };
+		73E4FBF02ADC4D01009A985A /* RefreshLatestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E4FBEF2ADC4D01009A985A /* RefreshLatestOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -228,6 +229,7 @@
 		7397C1E129091BC3002D5CDB /* uade_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = uade_ios.xcframework; path = "../uade-ios/uade_ios.xcframework"; sourceTree = "<group>"; };
 		739B4BF32720850200C2D69F /* RadioSessionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioSessionCell.swift; sourceTree = "<group>"; };
 		73CE92E42AAF03D1000BFC1C /* PlaylistPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistPresenter.swift; sourceTree = "<group>"; };
+		73E4FBEF2ADC4D01009A985A /* RefreshLatestOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshLatestOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -511,6 +513,7 @@
 				45D61F5A20E1780D00869814 /* Appearance.swift */,
 				45855FCC2444AC6B0079C767 /* ModuleSharing.swift */,
 				45B5FC25255D997000282550 /* ReviewActions.swift */,
+				73E4FBEF2ADC4D01009A985A /* RefreshLatestOperation.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -726,6 +729,7 @@
 				45AA910620FF36C200794147 /* MPTReplayer.m in Sources */,
 				451B6AA72204BBBB001848FA /* ModuleStorage.swift in Sources */,
 				4543983620D0344F00991ADC /* AboutInteractor.swift in Sources */,
+				73E4FBF02ADC4D01009A985A /* RefreshLatestOperation.swift in Sources */,
 				451B6AA32204B6CC001848FA /* LocalModels.swift in Sources */,
 				45AA7AED2101BDB10096D7E7 /* ModulePlayer.swift in Sources */,
 				456E6F2E240A5FAF0034BDA2 /* PlaylistView.swift in Sources */,

--- a/4champ/Info.plist
+++ b/4champ/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>fourchamp.latest.refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/4champ/Utils/RefreshLatestOperation.swift
+++ b/4champ/Utils/RefreshLatestOperation.swift
@@ -1,0 +1,91 @@
+//
+//  BackgroundFetchOp.swift
+//  ampplayer
+//
+//  Created by Aleksi Sitomaniemi on 15.10.2023.
+//  Copyright © 2023 Aleksi Sitomaniemi. All rights reserved.
+//
+
+import Foundation
+import NotificationCenter
+import Alamofire
+
+class RefershLatestOperation: Operation {
+   private var _executing = false
+   private var _finished = false
+
+   override private(set) var isExecuting: Bool {
+       get {
+           return _executing
+       }
+       set {
+           willChangeValue(forKey: "isExecuting")
+           _executing = newValue
+           didChangeValue(forKey: "isExecuting")
+       }
+   }
+
+   override private(set) var isFinished: Bool {
+       get {
+           return _finished
+       }
+       set {
+           willChangeValue(forKey: "isFinished")
+           _finished = newValue
+           didChangeValue(forKey: "isFinished")
+       }
+   }
+
+   override func start() {
+       if isCancelled {
+           isFinished = true
+           return
+       }
+
+       isExecuting = true
+       main() // Call your main method to perform the task
+   }
+
+   override func main() {
+       // Send a REST request to refresh app contents
+       log.debug("")
+       let req = RESTRoutes.latestId
+       AF.request(req).validate().responseString { resp in
+           switch resp.result {
+           case .failure:
+               self.cancel()
+           case .success(let str):
+               guard let collectionSize = Int(str) else {
+                   self.completeOperation()
+                   return
+               }
+               log.info("Collection Size: \(collectionSize)")
+               self.updateCollectionSize(size: collectionSize)
+               self.completeOperation()
+           }
+       }
+   }
+
+   private func completeOperation() {
+       isExecuting = false
+       isFinished = true
+   }
+
+  func updateCollectionSize(size: Int) {
+    log.debug("")
+    settings.collectionSize = size
+    let prevSize = settings.prevCollectionSize
+
+    // Only fire the request once per a given collectionSize/diff
+    if prevSize < size && settings.badgeCount < Constants.maxBadgeValue {
+      let fmt = "Radio_Notification".l13n()
+      let content = UNMutableNotificationContent()
+      content.body = String.init(format: fmt, "\(settings.badgeCount)")
+      content.categoryIdentifier = "newmodules"
+      let trigger = UNTimeIntervalNotificationTrigger.init(timeInterval: 0.1, repeats: false)
+      let req = UNNotificationRequest.init(identifier: "newmodules-usernotif", content: content, trigger: trigger)
+      UNUserNotificationCenter.current().add(req, withCompletionHandler: nil)
+      settings.prevCollectionSize = settings.collectionSize
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the Refresh Latest -operation to run with `BGTaskScheduler` instead of the deprecated `UIBackgroundFetch` API.