### PR TITLE
Persist custom channel setup between sessions

### DIFF
--- a/4champ/Scenes/Radio/RadioInteractor.swift
+++ b/4champ/Scenes/Radio/RadioInteractor.swift
@@ -92,8 +92,7 @@ class RadioInteractor: NSObject, RadioBusinessLogic, RadioDataStore, RadioRemote
   private var ntfAuthorization: UNAuthorizationStatus = .notDetermined
   private var playbackTimer: Timer?
   private var customChannelIndex = 0 // index of module in custom channel
-  var customSelection: Radio.CustomSelection = Radio.CustomSelection(name: "Radio_Custom".l13n(), ids: [])
-
+  var customSelection: Radio.CustomSelection = settings.radioCustomSelection
   // Keep session history for getting back to modules listened in the radio mode.
   private var radioSessionHistory: [MMD] = []
 
@@ -198,6 +197,7 @@ class RadioInteractor: NSObject, RadioBusinessLogic, RadioDataStore, RadioRemote
       } else {
         customSelection = selection
       }
+      settings.radioCustomSelection = customSelection
       channel = .custom
     default:
       channel = request.channel

--- a/4champ/Scenes/Radio/RadioModels.swift
+++ b/4champ/Scenes/Radio/RadioModels.swift
@@ -38,7 +38,7 @@ enum RadioStatus {
 }
 
 enum Radio {
-  struct CustomSelection {
+  struct CustomSelection: Encodable, Decodable {
     let name: String
     let ids: [Int]
   }

--- a/4champ/Scenes/Radio/RadioViewController.swift
+++ b/4champ/Scenes/Radio/RadioViewController.swift
@@ -122,7 +122,7 @@ class RadioViewController: UIViewController, RadioDisplayLogic {
     channelSegments?.setTitle("Radio_All".l13n(), forSegmentAt: 0)
     channelSegments?.setTitle("Radio_New".l13n(), forSegmentAt: 1)
     channelSegments?.setTitle("Radio_Local".l13n(), forSegmentAt: 2)
-    updateCustomChannelSegment(selection: Radio.CustomSelection(name: "Radio_Custom".l13n(), ids: []))
+    updateCustomChannelSegment(selection: router?.dataStore?.customSelection)
 
     channelSegments?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: .selected)
     channelSegments?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .normal)

--- a/4champ/Scenes/Settings/SettingsInteractor.swift
+++ b/4champ/Scenes/Settings/SettingsInteractor.swift
@@ -39,6 +39,7 @@ class SettingsInteractor: SettingsBusinessLogic, SettingsDataStore {
     static let interpolation = "interpolation"
     static let amigaResampler = "amigaResampler"
     static let moduleSortKey = "moduleSortKey"
+    static let radioCustomSelection = "radioCustomSelection"
   }
 
   var presenter: SettingsPresentationLogic?
@@ -138,6 +139,22 @@ class SettingsInteractor: SettingsBusinessLogic, SettingsDataStore {
     set {
       UserDefaults.standard.set(newValue.rawValue, forKey: SettingKeys.moduleSortKey)
     }
+  }
+  
+  var radioCustomSelection: Radio.CustomSelection {
+    get {
+      if let data = UserDefaults.standard.string(forKey: SettingKeys.radioCustomSelection),
+         let value = try? JSONDecoder().decode(Radio.CustomSelection.self, from: data.data(using: .utf8)!) {
+        return value
+      }
+      return Radio.CustomSelection(name: "Radio_Custom".l13n(), ids: [])
+    }
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        UserDefaults.standard.set(String(data: data, encoding: .utf8) ?? "", forKey: SettingKeys.radioCustomSelection)
+      }
+    }
+    
   }
 
   // MARK: Do something


### PR DESCRIPTION
The custom channel set up via search is now persisted in the app settings, meaning that user can start the same channel again without having to redo the search even if the app has been shut down in the meanwhile.